### PR TITLE
Fixed a missing import

### DIFF
--- a/blueprints/dumb/files/__root__/components/__name__/index.js
+++ b/blueprints/dumb/files/__root__/components/__name__/index.js
@@ -1,4 +1,5 @@
 import React, { Component } from 'react'
+import DocumentMeta from 'react-document-meta';
 
 /* component styles */
 import { styles } from './styles.scss';


### PR DESCRIPTION
I modified a dumb blueprint template. A render method uses DocumentMeta component and therefore was required import it from the react-document-meta module.
